### PR TITLE
feat: add FP4 evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,18 @@
 
 Atom is an accurate low-bit weight-activation quantization algorithm that combines (1) mixed-precision, (2) fine-grained group quantization, (3) dynamic activation quantization, (4) KV-cache quantization, and (5) efficient CUDA kernels co-design. 
 
-This codebase utilizes [lm_eval](https://github.com/EleutherAI/lm-evaluation-harness.git) to evaluate perplexity and zero-shot accuracy on Llama models. And code segments from [SmoothQuant](https://github.com/mit-han-lab/smoothquant.git), [GPTQ](https://github.com/IST-DASLab/gptq.git), and [SparseGPT](https://github.com/IST-DASLab/sparsegpt.git) are integrated to reproduce results. Our kernels are modified based on previous version of [FlashInfer](https://github.com/flashinfer-ai/flashinfer) and tested by [NVBench](https://github.com/NVIDIA/nvbench/tree/main). Serving framework [Punica](https://github.com/punica-ai/punica) is integrated to evaluate end-to-end throughput and latency.
+This codebase utilizes [lm_eval](https://github.com/EleutherAI/lm-evaluation-harness.git) to evaluate perplexity and zero-shot accuracy. Code segments from [SmoothQuant](https://github.com/mit-han-lab/smoothquant.git), [GPTQ](https://github.com/IST-DASLab/gptq.git), and [SparseGPT](https://github.com/IST-DASLab/sparsegpt.git) are integrated to reproduce results. Our kernels are modified based on previous version of [FlashInfer](https://github.com/flashinfer-ai/flashinfer) and tested by [NVBench](https://github.com/NVIDIA/nvbench/tree/main). Serving framework [Punica](https://github.com/punica-ai/punica) is integrated to evaluate end-to-end throughput and latency. We also use [BitsandBytes](https://github.com/TimDettmers/bitsandbytes) for new data-type evaluations (e.g., FP4). We thank the authors for their great works.
 
 The current release features:
-* Simulated quantization process for accuracy evaluation.
+* Simulated quantization for accuracy evaluation.
 * Perplexity and zero-shot accuracy evaluation
-* Kernel & End-to-end evaluation
+* Kernel benchmark & End-to-end evaluation
 
 To do:
 - [x] Release code for reproducing results.
 - [x] Release code for end-to-end throughput evaluation.
+- [x] Add FP4 accuracy evaluation for both weight and activation quantization.
+- [ ] Add support for Mixtral models.
 - [ ] Optimize kernel for different GPUs.
 - [ ] Full inference workflow in real production scenario.
 
@@ -62,7 +64,7 @@ make -j
 ## Usage
 ### Accuracy Evaluation
 Before running this command, please download Llama model from [Hugging Face website](https://huggingface.co/models?sort=trending&search=llama) first.
-We recommend downloading from [HuggyLlama](https://huggingface.co/huggyllama).
+We recommend downloading from [Deca-Llama](https://huggingface.co/linhvu/decapoda-research-llama-7b-hf/tree/main).
 
 We provide several scripts to reproduce our results in the paper:
 
@@ -93,7 +95,7 @@ python model/llama.py /Path/To/Llama/Model wikitext2 \
     --eval_ppl --eval_common_sense
 ```
 ### Efficiency Evaluation
-We evaluate Atom on a RTX4090 GPU. Results below are executed in [cu113](https://hub.docker.com/layers/nvidia/cuda/11.3.1-cudnn8-devel-ubuntu20.04/images/sha256-052b3b515d9653f9c6e358e5b70f8bb9d75c17a8b2039055674dfa7caa970791?context=explore) docker container.
+We evaluate Atom on a RTX4090 GPU. Results below are executed in [cu113](https://hub.docker.com/layers/nvidia/cuda/11.3.1-cudnn8-devel-ubuntu20.04/images/sha256-052b3b515d9653f9c6e358e5b70f8bb9d75c17a8b2039055674dfa7caa970791?context=explore) docker container. Note that current kernels are only optimized for RTX4090.
 
 To get INT4 GEMM kernel result, please execute:
 ```
@@ -108,9 +110,10 @@ Other kernel of Atom can be evaluated similarly, for e.g., `./bench_reorder`. We
 To reproduce end-to-end throughput and latency evaluation, please check [e2e/README.md](./e2e/README.md).
 ## Key Results
 ### Perplexity
-* Atom achieves strong perplexity results across WikiText2, PTB and C4 datasets across on Llama models family.
+We evaluate Atom's accuracy on serveral model families, including Llama, Llama-2, and OPT.
+* WikiText2, PTB and C4 datasets on Llama family:
 ![perplexity](figures/atom_ppl.png)
-* Below is Atom's WikiText2 perplexity of OPT, comparing with SmoothQuant and OmniQuant. Note that for OPT-66B, Atom's result is without using GPTQ optimization.
+* WikiText2 comparing with SmoothQuant and OmniQuant on OPT:
 
 |#Bit|Method|OPT-6.7B|OPT-13B|OPT-30B|OPT-66B|
 |-|-|-|-|-|-|
@@ -124,7 +127,7 @@ To reproduce end-to-end throughput and latency evaluation, please check [e2e/REA
 ![e2e](figures/atom_e2e_eval.png)
 
 ## Reference
-If you find Atom is helpful to your research, please consider to cite our paper:
+If you find this project is helpful to your research, please consider to cite our paper:
 ```
 @article{zhao2023atom,
   title={Atom: Low-bit Quantization for Efficient and Accurate LLM Serving},

--- a/model/gptq.py
+++ b/model/gptq.py
@@ -271,7 +271,7 @@ class GPTQ:
         # print('error', torch.sum(Losses).item())
         
         if self.n_out > 0:
-            keep_w = W[:,self.n_nonout:]
+            keep_w = W[:,self.n_nonout:].contiguous()
 
             if self.keeper_precision > 0:
                 if self.keeper_precision == 1:

--- a/model/main.py
+++ b/model/main.py
@@ -21,7 +21,7 @@ def get_llama(model):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     from transformers import LlamaForCausalLM
-    model = LlamaForCausalLM.from_pretrained(model, torch_dtype=torch.float16, device_map="auto")
+    model = LlamaForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
     model.seqlen = 2048
     return model
 
@@ -33,7 +33,7 @@ def get_opt(model):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     from transformers import OPTForCausalLM
-    model = OPTForCausalLM.from_pretrained(model, torch_dtype=torch.float16, device_map="auto")
+    model = OPTForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
     model.seqlen = model.config.max_position_embeddings
     return model
 

--- a/model/main.py
+++ b/model/main.py
@@ -21,7 +21,7 @@ def get_llama(model):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     from transformers import LlamaForCausalLM
-    model = LlamaForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
+    model = LlamaForCausalLM.from_pretrained(model, torch_dtype=torch.float16, device_map="auto")
     model.seqlen = 2048
     return model
 
@@ -33,7 +33,7 @@ def get_opt(model):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     from transformers import OPTForCausalLM
-    model = OPTForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
+    model = OPTForCausalLM.from_pretrained(model, torch_dtype=torch.float16, device_map="auto")
     model.seqlen = model.config.max_position_embeddings
     return model
 
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--exponential', action='store_true',
-        help='Whether to use exponential-only for weight quantization.'
+        help='Whether to use exponent-only for weight quantization.'
     )
     parser.add_argument(
         '--a_sym', action='store_true',
@@ -169,6 +169,10 @@ if __name__ == '__main__':
     parser.add_argument(
         '--save_dir', type=str, default='./saved',
         help='Path to store the reordering indices and quantized weights.'
+    )
+    parser.add_argument(
+        '--quant_type', type=str, default='int', choices=['int', 'fp'],
+        help='Determine the mapped data format by quant_type + n_bits. e.g. int8, fp4.'
     )
     
     args = parser.parse_args()

--- a/model/qLinearLayer.py
+++ b/model/qLinearLayer.py
@@ -65,7 +65,8 @@ class QLinearLayer(nn.Module):
             group_size=self.args.weight_group_size,
             channel_group=self.args.weight_channel_group,
             clip_ratio=self.args.w_clip_ratio,
-            tiling=self.args.tiling
+            tiling=self.args.tiling,
+            quant_type=self.args.quant_type
         )
 
         if self.args.keeper > 0:

--- a/model/quant.py
+++ b/model/quant.py
@@ -1,11 +1,10 @@
 import torch
 from torch import nn
 from functools import partial
-
-# Prototype for tile-wise quantization operator
-# from myCuda_functions import tensor_to_blocks, blocks_to_tensor
+from bitsandbytes.functional import quantize_fp4, dequantize_fp4
 
 # Fake round from S1E5M10 to S1E5M2
+# Direct Cast into FP8 instead of affine mapping
 @torch.no_grad()
 def fake_quantize_quarter_E5M2(w: torch.tensor) -> torch.tensor:
     # Sign:     1000 0000 0000 0000 HEX: 0x8000
@@ -24,6 +23,7 @@ def fake_quantize_quarter_E5M2(w: torch.tensor) -> torch.tensor:
     return w.view(torch.float16)
 
 # Fake round from S1E5M10 to S1E4M3
+# Direct Cast into FP8 instead of affine mapping
 def fake_quantize_quarter_E4M3(w: torch.tensor) -> torch.tensor:
     # Ref: https://www.h-schmidt.net/FloatConverter/IEEE754.html
     # Sign:     1000 0000 0000 0000 HEX: 0x8000
@@ -63,113 +63,127 @@ def fake_quantize_quarter_E4M3(w: torch.tensor) -> torch.tensor:
     w[~subNormalMask] = (w[~subNormalMask] & 0x8000) + mantissa[~subNormalMask] + exponent[~subNormalMask]
     return w.view(torch.float16)
 
-
+# Wrapper function for weight quantization
+# Continous number of channel_group channels share the same quantization setup
 @torch.no_grad()
-def quantize_tensor_channel_group(W: torch.tensor, n_bits, group_size, tiling, sym, channel_group=1, clip_ratio=1.0, exponential=False) -> torch.tensor:
-    # savedShape = W.shape
-    assert W.dim() == 2 or W.shape[0] == 1, "Current only support bsz=1"
-    assert group_size == 0 or tiling == 0
+def quantize_tensor_channel_group(W: torch.tensor, n_bits, group_size, tiling, sym, channel_group=1, clip_ratio=1.0, exponential=False, quant_type="int") -> torch.tensor:
     assert W.is_contiguous(), "Input tensor is not contiguous"
     assert n_bits < 16
 
-    # group_size = 0 is per-channel quantization
     if group_size > 0:
         assert W.shape[-1] % group_size == 0
 
+    # group_size = 0 is per-channel quantization.
     if group_size == 0:
         W = quantize_tensor(W, n_bits=n_bits, group_size=0, tiling=tiling, sym=sym, exponential=exponential)
     else:
         for i1 in range(0, W.shape[1], group_size):
             i2 = min(i1 + group_size, W.shape[1])
             w = W[:,i1:i2]
-            if channel_group > 1:
-                w = w.reshape(int(W.shape[0]/channel_group), -1)
 
+            # Continous channels share the same quantization setup.
+            # This trick is used for efficiency consideration.
+            if channel_group > 1:
+                w = w.reshape(int(W.shape[0]/channel_group), -1).contiguous() # Continous for bitsandbytes kernel calling
+            
+            # group_size is set to 0 because the layout is
+            # already [num_groups, group_size]
             w = quantize_tensor(
-                w, n_bits=n_bits, group_size=0, tiling=tiling, sym=sym, clip_ratio=clip_ratio, exponential=exponential
+                w,
+                n_bits=n_bits,
+                group_size=0,
+                tiling=tiling,
+                sym=sym,
+                clip_ratio=clip_ratio,
+                exponential=exponential,
+                quant_type=quant_type
             )
 
+            # Reshape back to original shape.
             if channel_group > 1:
                 w = w.reshape(-1, group_size)
             W[:,i1:i2] = w
 
-    return W
+    return W.contiguous()
 
+# Basic tool function for quantization
+# w: input tensor. should be either grouped with group_size = 0 or group_size > 0
+# n_bits: mapped data format width
+# group_size: quantization granularity
+# tiling: abandoned options for block-wise (e.g., 16x16) granularity
+# sym: symmetric quantization
+# clip_ratio: clip the maximum value of absmax. Not used in bitsandbytes kernels.
+# exponential: exponent-only data format, not used in Atom
+# quant_type: ["int", "fp"] choosing from uniform/non-uniform quantization
 @torch.no_grad()
-def quantize_tensor(w: torch.tensor, n_bits, group_size, tiling, sym, clip_ratio=1.0, exponential=False) -> torch.tensor:
+def quantize_tensor(w: torch.tensor, n_bits, group_size, tiling, sym, clip_ratio=1.0, exponential=False, quant_type="int") -> torch.tensor:
     savedShape = w.shape
-    assert w.dim() == 2 or savedShape[0] == 1, "Current only support bsz=1"
-    assert group_size == 0 or tiling == 0
-    # assert w.is_contiguous(), "Input tensor is not contiguous"
-
     w = w.squeeze()
-    newSavedShape = w.shape # Saved [row, columns]
+    assert w.is_contiguous(), "tensor should be continous for bitsandbytes kernel."
 
     if tiling > 0:
-        assert tiling == 16, "Currently only support tiling=16"
-        assert w.numel() % (tiling**2) == 0, f"shape {w.shape}, {w.numel()} is not divisible by {tiling**2}"
-        assert newSavedShape[0] % tiling == 0 and newSavedShape[1] % tiling == 0
-
-        swapTensor = torch.rand(w.numel() // (tiling**2), (tiling**2), device=w.device, dtype=w.dtype)
-        tensor_to_blocks(w, swapTensor, tiling)
-        w, swapTensor = swapTensor, w
+        assert False, "16x16 Block-wise Quantization is abandoned in this project."
 
     if group_size > 0:
         assert w.shape[-1] % group_size == 0
         w = w.reshape(-1, group_size) # row-major order
 
-    assert w.dim() == 2, "Weight format: [-1, group]"
+    assert w.dim() == 2, "Weight format should be: [num_groups, group_size]"
     assert n_bits < 16
-
-    if sym:
-        w_max = w.abs().amax(dim=-1, keepdim=True).clamp(min=1e-5)
-    else:
-        w_max = w.amax(dim=-1, keepdim=True)
-        w_min = w.amin(dim=-1, keepdim=True)
-
-    if exponential:
-        q_max = (2**(2**(n_bits-1)-1))
-        q_min = (1)
-        if sym:
-            scales = w_max
-            base = torch.zeros_like(scales)
-        else:
-            scales = (w_max-w_min) * torch.tensor(0.5)
-            base = (w_max+w_min) * torch.tensor(0.5)
-        scales.div_(q_max)
-        w = w - base
-        w_sign = torch.sign(w)
-        log_scaled_w = torch.log2((torch.abs(w) / scales).clamp(min=q_min, max=q_max))
-        int_scaled_w = torch.floor(log_scaled_w)
-        complement = (log_scaled_w - int_scaled_w > torch.log2(torch.tensor(1.5))).int()
-        int_scaled_w = int_scaled_w + complement
-        w = (2 ** int_scaled_w) * w_sign * scales
-        w = w + base
-    else: # uniform affine mapping
-        if sym:
-            q_max = (2**(n_bits-1)-1)
-            q_min = (-2**(n_bits-1))
-            if clip_ratio < 1.0:
-                w_max = w_max * clip_ratio
-            scales = w_max / q_max
-            base = torch.zeros_like(scales)
-        else:
-            q_max = (2**(n_bits)-1)
-            q_min = (0)
-            if clip_ratio < 1.0:
-                w_max *= clip_ratio
-                w_min *= clip_ratio
-            scales = (w_max-w_min).clamp(min=1e-5) / q_max
-            base = torch.round(-w_min/scales).clamp_(min=q_min, max=q_max)
-        w = (torch.clamp(torch.round(w / scales) + base, q_min, q_max) - base) * scales
     
-    if tiling > 0:
-        blocks_to_tensor(w, swapTensor, tiling)
-        w, swapTensor = swapTensor, w
-        del swapTensor
+    if quant_type == "fp":
+        assert n_bits == 4, "Only support FP4 quantization. You can add more by using bnb library."
+        real_quantized_w, quant_metadata = quantize_fp4(w, blocksize=w.shape[1])
+        w = dequantize_fp4(real_quantized_w, quant_metadata)
+        del real_quantized_w, quant_metadata
+    else:
+        assert quant_type == "int", "Options should be in [int, fp]"
+        if sym:
+            w_max = w.abs().amax(dim=-1, keepdim=True).clamp(min=1e-5)
+        else:
+            w_max = w.amax(dim=-1, keepdim=True)
+            w_min = w.amin(dim=-1, keepdim=True)
+
+        if exponential:
+            q_max = (2**(2**(n_bits-1)-1))
+            q_min = (1)
+            if sym:
+                scales = w_max
+                base = torch.zeros_like(scales)
+            else:
+                scales = (w_max-w_min) * torch.tensor(0.5)
+                base = (w_max+w_min) * torch.tensor(0.5)
+            scales.div_(q_max)
+            w = w - base
+            w_sign = torch.sign(w)
+            log_scaled_w = torch.log2((torch.abs(w) / scales).clamp(min=q_min, max=q_max))
+            int_scaled_w = torch.floor(log_scaled_w)
+            complement = (log_scaled_w - int_scaled_w > torch.log2(torch.tensor(1.5))).int()
+            int_scaled_w = int_scaled_w + complement
+            w = (2 ** int_scaled_w) * w_sign * scales
+            w = w + base
+        else: # uniform affine mapping
+            if sym:
+                q_max = (2**(n_bits-1)-1)
+                q_min = (-2**(n_bits-1))
+                if clip_ratio < 1.0:
+                    w_max = w_max * clip_ratio
+                scales = w_max / q_max
+                base = torch.zeros_like(scales)
+            else:
+                q_max = (2**(n_bits)-1)
+                q_min = (0)
+                if clip_ratio < 1.0:
+                    w_max *= clip_ratio
+                    w_min *= clip_ratio
+                scales = (w_max-w_min).clamp(min=1e-5) / q_max
+                base = torch.round(-w_min/scales).clamp_(min=q_min, max=q_max)
+            w = (torch.clamp(torch.round(w / scales) + base, q_min, q_max) - base) * scales
     
     return w.reshape(savedShape)
 
+# Wrapper function for activation quantization
+# Simulate mixed-precision by decomposing input
 @torch.no_grad()
 def quantize_activation_wrapper(x: torch.tensor, args) -> torch.tensor:
     if args.abits >= 16:
@@ -181,7 +195,9 @@ def quantize_activation_wrapper(x: torch.tensor, args) -> torch.tensor:
         group_size=args.act_group_size, 
         tiling=args.tiling, 
         sym=args.a_sym,
-        clip_ratio=args.a_clip_ratio
+        clip_ratio=args.a_clip_ratio,
+        exponential=False,
+        quant_type=args.quant_type
     )
 
     savedShape = x.shape
@@ -192,7 +208,8 @@ def quantize_activation_wrapper(x: torch.tensor, args) -> torch.tensor:
     if args.keeper > 0:
         saved_x = x[:, -args.keeper:].clone().contiguous()
     
-    # Whether to keep outliers in FP8
+    # Mixed-precision for outliers
+    # FP8/INT8/FP16
     if args.keeper and args.keeper_precision > 0:
         assert args.keeper > 0, "Keeper must be greater than 0"
         if args.keeper_precision == 1:
@@ -201,10 +218,12 @@ def quantize_activation_wrapper(x: torch.tensor, args) -> torch.tensor:
             saved_x = fake_quantize_quarter_E4M3(saved_x)
         elif args.keeper_precision == 3:
             saved_x = quantize_tensor(saved_x, n_bits=8, group_size=0, tiling=0, sym=True, exponential=False)
-
+    # Set zero to avoid interference
     if args.keeper > 0:
         x[:, -args.keeper:] = 0
+    
     x = qFunction(x)
+    # Set back the outliers
     if args.keeper > 0:
         x[:, -args.keeper:] = saved_x
         del saved_x
@@ -215,15 +234,12 @@ def quantize_activation_wrapper(x: torch.tensor, args) -> torch.tensor:
 def quantize_attn_v_wrapper(w: torch.tensor, args) -> torch.tensor:
     # Input shape: [bsz, self.num_heads, seq_len, self.head_dim]
     # Quantize on head_dim
-    assert w.dim() == 4 or  w.dim() == 3
-    assert w.shape[-1] == 128
+    assert w.shape[-1] == 128, "KV Cache Quantization is per head granularity."
     
     head_dim = w.shape[-1]
     saved_shape = w.shape
     w = w.reshape(-1, head_dim)
 
-    # (g128, asym) == (g64, sym)
-    # Expressiness is almost equal to bits
     w = quantize_tensor(w, n_bits=args.abits, group_size=0, tiling=0, sym=False, clip_ratio=args.kv_clip_ratio, exponential=False)
     return w.view(saved_shape)
 
@@ -231,8 +247,7 @@ def quantize_attn_v_wrapper(w: torch.tensor, args) -> torch.tensor:
 def quantize_attn_k_wrapper(w: torch.tensor, args) -> torch.tensor:
     # Input shape: [bsz, self.num_heads, seq_len, self.head_dim]
     # Quantize on head_dim
-    assert w.dim() == 4 or  w.dim() == 3
-    assert w.shape[-1] == 128
+    assert w.shape[-1] == 128, "KV Cache Quantization is per head granularity."
     
     head_dim = w.shape[-1]
     saved_shape = w.shape
@@ -246,11 +261,14 @@ class Quantizer(nn.Module):
         super().__init__()
         self.register_buffer("scales", None)
         self.args = args
+        # act_quant are configured outside.
         self.act_quant = lambda x: x
 
     @torch.no_grad()
     def forward(self, hidden_states):
         if self.args.static == False or self.scales is None:
+            # Note that Atom is dynamic quantization.
+            # Therefore, this is the only valid path.
             return self.act_quant(hidden_states)
         
         savedShape = hidden_states.shape

--- a/model/requirements.txt
+++ b/model/requirements.txt
@@ -12,3 +12,4 @@ omegaconf==2.3.0
 pycountry==22.3.5
 rouge-score==0.1.2
 lm-eval==0.3.0
+bitsandbytes=0.43.0

--- a/model/requirements.txt
+++ b/model/requirements.txt
@@ -12,4 +12,4 @@ omegaconf==2.3.0
 pycountry==22.3.5
 rouge-score==0.1.2
 lm-eval==0.3.0
-bitsandbytes=0.43.0
+bitsandbytes==0.43.0

--- a/scripts/run_atom_ppl.sh
+++ b/scripts/run_atom_ppl.sh
@@ -21,7 +21,8 @@ resultFile=$dir/atom_llama_ppl.csv
 logFile=$dir/atom_llama_w${BIT}a${BIT}.log
 touch $logFile
 
-CUDA_VISIBLE_DEVICE=0 python ${dir}/model/main.py ${MODEL} ${CALIB_DATA} \
+export CUDA_VISIBLE_DEVICES=0 # Avoid causing not same devices error in "auto" device_map.
+python ${dir}/model/main.py ${MODEL} ${CALIB_DATA} \
     ${cmd_base} ${cmd_group} ${cmd_reorder} ${cmd_clip} ${cmd_adv} ${cmd_eval} \
     2>&1 | tee ${logFile}
 


### PR DESCRIPTION
This PR introduces the following enhancements:
1. Integret new data format support for Atom, e.g., FP4 (https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf). Utilize BitsandBytes for quantization (https://github.com/TimDettmers/bitsandbytes).
2. Polish and add more comments in codes. Polish the README.md.