### PR TITLE
[Major] Add support for Mixtral8x7b

### DIFF
--- a/model/eval.py
+++ b/model/eval.py
@@ -29,6 +29,7 @@ def llama_eval(model, testenc, dev):
         def __init__(self, module):
             super().__init__()
             self.module = module
+            self.self_attn = module.self_attn
         def forward(self, inp, **kwargs):
             inps[cache['i']] = inp
             cache['i'] += 1

--- a/model/main.py
+++ b/model/main.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from pprint import pprint
 from modelutils_llama import quantize_model_llama, reorder_model_llama, quantize_model_gptq_llama,  add_act_quant_wrapper_llama
 from modelutils_opt import quantize_model_opt, reorder_model_opt, quantize_model_gptq_opt,  add_act_quant_wrapper_opt
+from modelutils_mixtral import quantize_model_mixtral, add_act_quant_wrapper_mixtral
 from parallel_utils import map_layers_to_multi_gpus
 from LMClass import LMClass
 from eval import pattern_match
@@ -35,6 +36,18 @@ def get_opt(model):
     from transformers import OPTForCausalLM
     model = OPTForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
     model.seqlen = model.config.max_position_embeddings
+    return model
+
+def get_mixtral(model):
+    import torch
+    def skip(*args, **kwargs):
+        pass
+    torch.nn.init.kaiming_uniform_ = skip
+    torch.nn.init.uniform_ = skip
+    torch.nn.init.normal_ = skip
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    model = AutoModelForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
+    model.seqlen = 2048
     return model
 
 
@@ -196,6 +209,14 @@ if __name__ == '__main__':
         quantize_model_gptq_func = quantize_model_gptq_opt
         quantize_model_func = quantize_model_opt
         eval_func = opt_eval
+    elif "mixtral" in args.model.lower():
+        model = get_mixtral(args.model)
+        # get_act_stats_func = get_act_stats_mixtral
+        # reorder_model_func = reorder_model_mixtral
+        add_act_quant_wrapper_func = add_act_quant_wrapper_mixtral
+        # quantize_model_gptq_func = quantize_model_gptq_mixtral
+        quantize_model_func = quantize_model_mixtral
+        eval_func = llama_eval
     model.eval()
 
     import os

--- a/model/main.py
+++ b/model/main.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from pprint import pprint
 from modelutils_llama import quantize_model_llama, reorder_model_llama, quantize_model_gptq_llama,  add_act_quant_wrapper_llama
 from modelutils_opt import quantize_model_opt, reorder_model_opt, quantize_model_gptq_opt,  add_act_quant_wrapper_opt
-from modelutils_mixtral import quantize_model_mixtral, add_act_quant_wrapper_mixtral
+from modelutils_mixtral import quantize_model_mixtral, add_act_quant_wrapper_mixtral, reorder_model_mixtral
 from parallel_utils import map_layers_to_multi_gpus
 from LMClass import LMClass
 from eval import pattern_match
@@ -211,10 +211,10 @@ if __name__ == '__main__':
         eval_func = opt_eval
     elif "mixtral" in args.model.lower():
         model = get_mixtral(args.model)
-        # get_act_stats_func = get_act_stats_mixtral
-        # reorder_model_func = reorder_model_mixtral
+        get_act_stats_func = get_act_stats_llama
+        reorder_model_func = reorder_model_mixtral
         add_act_quant_wrapper_func = add_act_quant_wrapper_mixtral
-        # quantize_model_gptq_func = quantize_model_gptq_mixtral
+        quantize_model_gptq_func = quantize_model_gptq_llama
         quantize_model_func = quantize_model_mixtral
         eval_func = llama_eval
     model.eval()

--- a/model/main.py
+++ b/model/main.py
@@ -286,7 +286,7 @@ if __name__ == '__main__':
             param.requires_grad = False
 
         if args.multigpu:
-            if "llama" in args.model.lower():
+            if ("llama" in args.model.lower()) or ("mixtral" in args.model.lower()):
                 map_layers_to_multi_gpus(lm.model.model.layers)
                 input_device = lm.model.model.layers[0].device
                 output_device = lm.model.model.layers[-1].device

--- a/model/main.py
+++ b/model/main.py
@@ -21,7 +21,7 @@ def get_llama(model):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     from transformers import LlamaForCausalLM
-    model = LlamaForCausalLM.from_pretrained(model, torch_dtype=torch.float16, device_map="auto")
+    model = LlamaForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
     model.seqlen = 2048
     return model
 
@@ -33,7 +33,7 @@ def get_opt(model):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     from transformers import OPTForCausalLM
-    model = OPTForCausalLM.from_pretrained(model, torch_dtype=torch.float16, device_map="auto")
+    model = OPTForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
     model.seqlen = model.config.max_position_embeddings
     return model
 

--- a/model/main.py
+++ b/model/main.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from pprint import pprint
 from modelutils_llama import quantize_model_llama, reorder_model_llama, quantize_model_gptq_llama,  add_act_quant_wrapper_llama
 from modelutils_opt import quantize_model_opt, reorder_model_opt, quantize_model_gptq_opt,  add_act_quant_wrapper_opt
+from modelutils_mixtral import quantize_model_mixtral, add_act_quant_wrapper_mixtral
 from parallel_utils import map_layers_to_multi_gpus
 from LMClass import LMClass
 from eval import pattern_match
@@ -35,6 +36,18 @@ def get_opt(model):
     from transformers import OPTForCausalLM
     model = OPTForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
     model.seqlen = model.config.max_position_embeddings
+    return model
+
+def get_mixtral(model):
+    import torch
+    def skip(*args, **kwargs):
+        pass
+    torch.nn.init.kaiming_uniform_ = skip
+    torch.nn.init.uniform_ = skip
+    torch.nn.init.normal_ = skip
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    model = AutoModelForCausalLM.from_pretrained(model, torch_dtype=torch.float16)
+    model.seqlen = 2048
     return model
 
 
@@ -192,6 +205,14 @@ if __name__ == '__main__':
         quantize_model_gptq_func = quantize_model_gptq_opt
         quantize_model_func = quantize_model_opt
         eval_func = opt_eval
+    elif "mixtral" in args.model.lower():
+        model = get_mixtral(args.model)
+        # get_act_stats_func = get_act_stats_mixtral
+        # reorder_model_func = reorder_model_mixtral
+        add_act_quant_wrapper_func = add_act_quant_wrapper_mixtral
+        # quantize_model_gptq_func = quantize_model_gptq_mixtral
+        quantize_model_func = quantize_model_mixtral
+        eval_func = llama_eval
     model.eval()
 
     import os

--- a/model/modelutils_llama.py
+++ b/model/modelutils_llama.py
@@ -18,7 +18,6 @@ def reorder_model_llama(model, device, args, reorder_index):
 
     for i in tqdm(range(len(layers))):
         layers[i] = layers[i].to(device)
-        layers[i] = layers[i].to(device)
         if isinstance(layers[i], LlamaDecoderLayer):
             m = QLlamaDecoderLayer(
                 originalLayer=layers[i],
@@ -176,6 +175,7 @@ def quantize_model_gptq_llama(model, device, args, dataloader):
         def __init__(self, module):
             super().__init__()
             self.module = module
+            self.self_attn = module.self_attn
         def forward(self, inp, **kwargs):
             inps[cache['i']] = inp
             cache['i'] += 1
@@ -231,7 +231,8 @@ def quantize_model_gptq_llama(model, device, args, dataloader):
                 gptq[name].quantizer.configure(
                     args.wbits, perchannel=True, sym=args.w_sym, mse=False, 
                     channel_group=args.weight_channel_group,
-                    clip_ratio=args.w_clip_ratio
+                    clip_ratio=args.w_clip_ratio,
+                    quant_type=args.quant_type
                 )
                 
             def add_batch(name):

--- a/model/modelutils_llama.py
+++ b/model/modelutils_llama.py
@@ -3,8 +3,10 @@ import torch
 import torch.nn as nn
 from tqdm import tqdm
 from transformers.models.llama.modeling_llama import LlamaDecoderLayer
+from transformers.models.mixtral.modeling_mixtral import MixtralDecoderLayer
 from qLinearLayer import find_qlinear_layers
 from qLlamaLayer import QLlamaDecoderLayer
+from qMixtralLayer import QMixtralDecoderLayer
 from gptq import GPTQ, Quantizer_GPTQ
 from functools import partial
 
@@ -44,15 +46,12 @@ def reorder_model_llama(model, device, args, reorder_index):
         # Not reorder due to the RoPE embedding.
         m.self_attn.q_proj.reorder(
             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'q_proj', 'input')],
-            # out_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'output')]
             out_reorder_index=None
         )
         m.self_attn.k_proj.reorder(
             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'input')],
-            # out_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'output')]
             out_reorder_index=None
         )
-        
         m.self_attn.v_proj.reorder(
             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'v_proj', 'input')],
             out_reorder_index=None
@@ -201,16 +200,19 @@ def quantize_model_gptq_llama(model, device, args, dataloader):
 
     quantizers = {}
     for i in tqdm(range(len(layers))):
-        m = None
         if isinstance(layers[i], LlamaDecoderLayer):
             m = QLlamaDecoderLayer(
                 originalLayer=layers[i],
                 args=args,
             )
-        elif isinstance(layers[i], QLlamaDecoderLayer):
+        elif isinstance(layers[i], MixtralDecoderLayer):
+            m = QMixtralDecoderLayer(
+                originalLayer=layers[i],
+                args=args,
+            )
+        elif isinstance(layers[i], QLlamaDecoderLayer) or isinstance(layers[i], QMixtralDecoderLayer):
             m = layers[i]
-
-        if m is None:
+        else:
             continue
 
         layer = m.to(device)

--- a/model/modelutils_mixtral.py
+++ b/model/modelutils_mixtral.py
@@ -1,0 +1,250 @@
+import gc
+import torch
+import torch.nn as nn
+from tqdm import tqdm
+from transformers.models.mixtral.modeling_mixtral import MixtralDecoderLayer
+from qLinearLayer import find_qlinear_layers
+from qMixtralLayer import QMixtralDecoderLayer
+from gptq import GPTQ, Quantizer_GPTQ
+from functools import partial
+
+from quant import quantize_activation_wrapper, quantize_attn_v_wrapper, quantize_attn_k_wrapper
+
+# def reorder_model_llama(model, device, args, reorder_index):
+#     model.config.use_cache = False
+#     layers = model.model.layers
+#     assert reorder_index is not None, "Reorder index is None"
+# 
+# 
+#     for i in tqdm(range(len(layers))):
+#         layers[i] = layers[i].to(device)
+#         layers[i] = layers[i].to(device)
+#         if isinstance(layers[i], LlamaDecoderLayer):
+#             m = QLlamaDecoderLayer(
+#                 originalLayer=layers[i],
+#                 args=args,
+#             )
+#         elif isinstance(layers[i], QLlamaDecoderLayer):
+#             m = layers[i]
+#         
+#         nameTemplate = 'layers.{}.{}.{}.{}' # Something like layers.10.self_attn.q_proj
+# 
+#         m.mlp.gate_proj.reorder(
+#             in_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'gate_proj', 'input')],
+#             out_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'down_proj', 'input')]
+#         )
+#         m.mlp.up_proj.reorder(
+#             in_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'up_proj', 'input')],
+#             out_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'down_proj', 'input')]
+#         )
+#         m.mlp.down_proj.reorder(
+#             in_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'down_proj', 'input')],
+#             out_reorder_index=None
+#         )
+#         # K has outlier should be kept.
+#         # Not reorder due to the RoPE embedding.
+#         m.self_attn.q_proj.reorder(
+#             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'q_proj', 'input')],
+#             # out_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'output')]
+#             out_reorder_index=None
+#         )
+#         m.self_attn.k_proj.reorder(
+#             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'input')],
+#             # out_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'output')]
+#             out_reorder_index=None
+#         )
+#         
+#         m.self_attn.v_proj.reorder(
+#             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'v_proj', 'input')],
+#             out_reorder_index=None
+#         )
+#         m.self_attn.o_proj.reorder(
+#             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'o_proj', 'input')],
+#             out_reorder_index=None
+#         )
+#         m.input_layernorm.register_buffer('reorder_index', 
+#             reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'input')] # Random choose one from k,q,v proj.
+#         )
+#         m.post_attention_layernorm.register_buffer('reorder_index',
+#             reorder_index[nameTemplate.format(i, 'mlp', 'gate_proj', 'input')]
+#         )
+#         m.self_attn.register_buffer('reorder_index', reorder_index[nameTemplate.format(i, 'self_attn', 'o_proj', 'input')])
+# 
+#         layers[i] = layers[i].cpu()
+#         layers[i] = m.cpu()
+#         del m
+#         torch.cuda.empty_cache()
+#     return model
+# 
+
+def add_act_quant_wrapper_mixtral(model, device, args, scales):
+    model.config.use_cache = False
+    layers = model.model.layers
+    for i in tqdm(range(len(layers))):
+        if isinstance(layers[i], MixtralDecoderLayer):
+            m = QMixtralDecoderLayer(
+                originalLayer=layers[i],
+                args=args,
+            )
+        elif isinstance(layers[i], QMixtralDecoderLayer):
+            m = layers[i]
+        else:
+            continue
+
+        m = m.to(device)
+
+        m.self_attn.act_quant = partial(quantize_activation_wrapper, args=args)
+        m.self_attn.v_quant = partial(quantize_attn_v_wrapper, args=args)
+        m.self_attn.k_quant = partial(quantize_attn_k_wrapper, args=args)
+
+        for expert in m.block_sparse_moe.experts:
+            expert.act_quant = partial(quantize_activation_wrapper, args=args)
+
+        m.input_layernorm.act_quant = partial(quantize_activation_wrapper, args=args)
+        m.post_attention_layernorm.act_quant = partial(quantize_activation_wrapper, args=args)
+        
+        layers[i] = m.cpu()
+        torch.cuda.empty_cache()
+    return model
+
+def quantize_model_mixtral(model, device, args):
+    model.config.use_cache = False
+    layers = model.model.layers
+    for i in tqdm(range(len(layers))):
+        if isinstance(layers[i], MixtralDecoderLayer):
+            m = QMixtralDecoderLayer(
+                originalLayer=layers[i],
+                args=args,
+            )
+        elif isinstance(layers[i], QMixtralDecoderLayer):
+            m = layers[i]
+        else:
+            continue
+
+        m = m.to(device)
+        for expert in m.block_sparse_moe.experts:
+            expert.quant()
+
+        m.self_attn.q_proj.quant()
+        m.self_attn.k_proj.quant()
+        m.self_attn.v_proj.quant()
+        m.self_attn.o_proj.quant()
+
+        layers[i] = m.cpu()
+        torch.cuda.empty_cache()
+    return model
+
+# def quantize_model_gptq_llama(model, device, args, dataloader):
+#     print('Starting GPTQ quantization ...')
+# 
+#     use_cache = model.config.use_cache
+#     model.config.use_cache = False
+#     layers = model.model.layers
+# 
+#     model.model.embed_tokens = model.model.embed_tokens.to(device)
+#     model.model.norm = model.model.norm.to(device)
+#     layers[0] = layers[0].to(device)
+# 
+#     dtype = next(iter(model.parameters())).dtype
+#     inps = torch.zeros(
+#         (args.nsamples, model.seqlen, model.config.hidden_size), dtype=dtype, device=device
+#     )
+# 
+#     cache = {'i': 0, 'attention_mask': None}
+# 
+#     class Catcher(nn.Module):
+#         def __init__(self, module):
+#             super().__init__()
+#             self.module = module
+#         def forward(self, inp, **kwargs):
+#             inps[cache['i']] = inp
+#             cache['i'] += 1
+#             cache['attention_mask'] = kwargs['attention_mask']
+#             cache['position_ids'] = kwargs['position_ids']
+#             raise ValueError
+#     
+#     layers[0] = Catcher(layers[0])
+#     for batch in dataloader:
+#         try:
+#             model(batch[0].to(device))
+#         except ValueError:
+#             pass
+#     layers[0] = layers[0].module
+#     layers[0] = layers[0].cpu()
+#     model.model.embed_tokens = model.model.embed_tokens.cpu()
+#     model.model.norm = model.model.norm.cpu()
+#     torch.cuda.empty_cache()
+# 
+#     outs = torch.zeros_like(inps)
+#     attention_mask = cache['attention_mask']
+#     position_ids = cache['position_ids']
+# 
+#     quantizers = {}
+#     for i in tqdm(range(len(layers))):
+#         m = None
+#         if isinstance(layers[i], LlamaDecoderLayer):
+#             m = QLlamaDecoderLayer(
+#                 originalLayer=layers[i],
+#                 args=args,
+#             )
+#         elif isinstance(layers[i], QLlamaDecoderLayer):
+#             m = layers[i]
+# 
+#         if m is None:
+#             continue
+# 
+#         layer = m.to(device)
+# 
+#         block_layers = find_qlinear_layers(layer)
+# 
+#         sequential = [list(block_layers.keys())]
+#        
+#         for names in sequential:
+#             subset = {n: block_layers[n] for n in names}
+# 
+#             gptq = {}
+#             for name in subset:
+#                 gptq[name] = GPTQ(
+#                     subset[name], n_out=args.keeper, keeper_precision=args.keeper_precision
+#                 )
+#                 gptq[name].quantizer = Quantizer_GPTQ()
+#                 gptq[name].quantizer.configure(
+#                     args.wbits, perchannel=True, sym=args.w_sym, mse=False, 
+#                     channel_group=args.weight_channel_group,
+#                     clip_ratio=args.w_clip_ratio
+#                 )
+#                 
+#             def add_batch(name):
+#                 def tmp(_, inp, out):
+#                     gptq[name].add_batch(inp[0].data, out.data)
+#                 return tmp
+# 
+#             handles = []
+#             for name in subset:
+#                 handles.append(subset[name].register_forward_hook(add_batch(name)))
+#             for j in range(args.nsamples):
+#                 layer(inps[j].unsqueeze(0), attention_mask=attention_mask, position_ids=position_ids)[0]
+#             for h in handles:
+#                 h.remove()
+#             
+#             for name in subset:
+#                 gptq[name].fasterquant(
+#                     percdamp=args.percdamp, groupsize=args.weight_group_size
+#                 )
+#                 quantizers['model.layers.%d.%s' % (i, name)] = gptq[name].quantizer.cpu()
+#                 gptq[name].free()
+# 
+#             del gptq
+# 
+#         for j in range(args.nsamples):
+#             outs[j] = layer(inps[j].unsqueeze(0), attention_mask=attention_mask, position_ids=position_ids)[0]
+# 
+#         layers[i] = layer.cpu()
+#         del layer, m
+#         torch.cuda.empty_cache()
+#         gc.collect()
+# 
+#         inps, outs = outs, inps
+# 
+#     model.config.use_cache = use_cache
+#     return model

--- a/model/modelutils_mixtral.py
+++ b/model/modelutils_mixtral.py
@@ -10,72 +10,86 @@ from functools import partial
 
 from quant import quantize_activation_wrapper, quantize_attn_v_wrapper, quantize_attn_k_wrapper
 
-# def reorder_model_llama(model, device, args, reorder_index):
-#     model.config.use_cache = False
-#     layers = model.model.layers
-#     assert reorder_index is not None, "Reorder index is None"
-# 
-# 
-#     for i in tqdm(range(len(layers))):
-#         layers[i] = layers[i].to(device)
-#         layers[i] = layers[i].to(device)
-#         if isinstance(layers[i], LlamaDecoderLayer):
-#             m = QLlamaDecoderLayer(
-#                 originalLayer=layers[i],
-#                 args=args,
-#             )
-#         elif isinstance(layers[i], QLlamaDecoderLayer):
-#             m = layers[i]
-#         
-#         nameTemplate = 'layers.{}.{}.{}.{}' # Something like layers.10.self_attn.q_proj
-# 
-#         m.mlp.gate_proj.reorder(
-#             in_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'gate_proj', 'input')],
-#             out_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'down_proj', 'input')]
-#         )
-#         m.mlp.up_proj.reorder(
-#             in_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'up_proj', 'input')],
-#             out_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'down_proj', 'input')]
-#         )
-#         m.mlp.down_proj.reorder(
-#             in_reorder_index=reorder_index[nameTemplate.format(i, 'mlp', 'down_proj', 'input')],
-#             out_reorder_index=None
-#         )
-#         # K has outlier should be kept.
-#         # Not reorder due to the RoPE embedding.
-#         m.self_attn.q_proj.reorder(
-#             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'q_proj', 'input')],
-#             # out_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'output')]
-#             out_reorder_index=None
-#         )
-#         m.self_attn.k_proj.reorder(
-#             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'input')],
-#             # out_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'output')]
-#             out_reorder_index=None
-#         )
-#         
-#         m.self_attn.v_proj.reorder(
-#             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'v_proj', 'input')],
-#             out_reorder_index=None
-#         )
-#         m.self_attn.o_proj.reorder(
-#             in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'o_proj', 'input')],
-#             out_reorder_index=None
-#         )
-#         m.input_layernorm.register_buffer('reorder_index', 
-#             reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'input')] # Random choose one from k,q,v proj.
-#         )
-#         m.post_attention_layernorm.register_buffer('reorder_index',
-#             reorder_index[nameTemplate.format(i, 'mlp', 'gate_proj', 'input')]
-#         )
-#         m.self_attn.register_buffer('reorder_index', reorder_index[nameTemplate.format(i, 'self_attn', 'o_proj', 'input')])
-# 
-#         layers[i] = layers[i].cpu()
-#         layers[i] = m.cpu()
-#         del m
-#         torch.cuda.empty_cache()
-#     return model
-# 
+def reorder_model_mixtral(model, device, args, reorder_index):
+    model.config.use_cache = False
+    layers = model.model.layers
+    assert reorder_index is not None, "Reorder index is None"
+
+
+    for i in tqdm(range(len(layers))):
+        layers[i] = layers[i].to(device)
+        layers[i] = layers[i].to(device)
+        if isinstance(layers[i], MixtralDecoderLayer):
+            m = QMixtralDecoderLayer(
+                originalLayer=layers[i],
+                args=args,
+            )
+        elif isinstance(layers[i], QMixtralDecoderLayer):
+            m = layers[i]
+
+        # reordering for the attention
+        nameTemplate = 'layers.{}.{}.{}.{}' # Something like layers.10.self_attn.q_proj
+
+        m.input_layernorm.register_buffer('reorder_index', 
+            reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'input')] # Random choose one from k,q,v proj.
+        )
+
+        # K has outlier should be kept.
+        # Not reorder due to the RoPE embedding.
+        m.self_attn.q_proj.reorder(
+            in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'input')],
+            out_reorder_index=None
+        )
+        m.self_attn.k_proj.reorder(
+            in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'input')],
+            out_reorder_index=None
+        )
+        
+        m.self_attn.v_proj.reorder(
+            in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'k_proj', 'input')],
+            out_reorder_index=None
+        )
+        m.self_attn.o_proj.reorder(
+            in_reorder_index=reorder_index[nameTemplate.format(i, 'self_attn', 'o_proj', 'input')],
+            out_reorder_index=None
+        )
+
+        m.self_attn.register_buffer('reorder_index', reorder_index[nameTemplate.format(i, 'self_attn', 'o_proj', 'input')])
+        
+        # reordering for the MoE
+        nameTemplate_moe = 'layers.{}.{}.{}.{}.{}.{}' # Something like layers.10.block_sparse_moe.experts.1.w1
+
+        # pick expert.0.w1's order and reorder all related modules
+        m.block_sparse_moe.gate.reorder(
+            in_reorder_index=reorder_index[nameTemplate_moe.format(i, 'block_sparse_moe', 'experts', 0, 'w1', 'input')],
+            out_reorder_index=None
+        )
+
+        num_experts = m.block_sparse_moe.num_experts
+        for j in range(num_experts):
+            m.block_sparse_moe.experts[j].w1.reorder(
+                in_reorder_index=reorder_index[nameTemplate_moe.format(i, 'block_sparse_moe', 'experts', 0, 'w1', 'input')],
+                out_reorder_index=reorder_index[nameTemplate_moe.format(i, 'block_sparse_moe', 'experts', 0, 'w2', 'input')]
+            )
+            m.block_sparse_moe.experts[j].w3.reorder(
+                in_reorder_index=reorder_index[nameTemplate_moe.format(i, 'block_sparse_moe', 'experts', 0, 'w1', 'input')],
+                out_reorder_index=reorder_index[nameTemplate_moe.format(i, 'block_sparse_moe', 'experts', 0, 'w2', 'input')]
+            )
+            m.block_sparse_moe.experts[j].w2.reorder(
+                in_reorder_index=reorder_index[nameTemplate_moe.format(i, 'block_sparse_moe', 'experts', 0, 'w2', 'input')],
+                out_reorder_index=None
+            )
+
+        m.post_attention_layernorm.register_buffer('reorder_index',
+            reorder_index[nameTemplate_moe.format(i, 'block_sparse_moe', 'experts', 0, 'w1', 'input')],
+        )
+
+        layers[i] = layers[i].cpu()
+        layers[i] = m.cpu()
+        del m
+        torch.cuda.empty_cache()
+    return model
+
 
 def add_act_quant_wrapper_mixtral(model, device, args, scales):
     model.config.use_cache = False
@@ -100,8 +114,8 @@ def add_act_quant_wrapper_mixtral(model, device, args, scales):
         for expert in m.block_sparse_moe.experts:
             expert.act_quant = partial(quantize_activation_wrapper, args=args)
 
-        m.input_layernorm.act_quant = partial(quantize_activation_wrapper, args=args)
-        m.post_attention_layernorm.act_quant = partial(quantize_activation_wrapper, args=args)
+        m.act_quant = partial(quantize_activation_wrapper, args=args)
+        m.block_sparse_moe.act_quant = partial(quantize_activation_wrapper, args=args)
         
         layers[i] = m.cpu()
         torch.cuda.empty_cache()
@@ -133,118 +147,3 @@ def quantize_model_mixtral(model, device, args):
         layers[i] = m.cpu()
         torch.cuda.empty_cache()
     return model
-
-# def quantize_model_gptq_llama(model, device, args, dataloader):
-#     print('Starting GPTQ quantization ...')
-# 
-#     use_cache = model.config.use_cache
-#     model.config.use_cache = False
-#     layers = model.model.layers
-# 
-#     model.model.embed_tokens = model.model.embed_tokens.to(device)
-#     model.model.norm = model.model.norm.to(device)
-#     layers[0] = layers[0].to(device)
-# 
-#     dtype = next(iter(model.parameters())).dtype
-#     inps = torch.zeros(
-#         (args.nsamples, model.seqlen, model.config.hidden_size), dtype=dtype, device=device
-#     )
-# 
-#     cache = {'i': 0, 'attention_mask': None}
-# 
-#     class Catcher(nn.Module):
-#         def __init__(self, module):
-#             super().__init__()
-#             self.module = module
-#         def forward(self, inp, **kwargs):
-#             inps[cache['i']] = inp
-#             cache['i'] += 1
-#             cache['attention_mask'] = kwargs['attention_mask']
-#             cache['position_ids'] = kwargs['position_ids']
-#             raise ValueError
-#     
-#     layers[0] = Catcher(layers[0])
-#     for batch in dataloader:
-#         try:
-#             model(batch[0].to(device))
-#         except ValueError:
-#             pass
-#     layers[0] = layers[0].module
-#     layers[0] = layers[0].cpu()
-#     model.model.embed_tokens = model.model.embed_tokens.cpu()
-#     model.model.norm = model.model.norm.cpu()
-#     torch.cuda.empty_cache()
-# 
-#     outs = torch.zeros_like(inps)
-#     attention_mask = cache['attention_mask']
-#     position_ids = cache['position_ids']
-# 
-#     quantizers = {}
-#     for i in tqdm(range(len(layers))):
-#         m = None
-#         if isinstance(layers[i], LlamaDecoderLayer):
-#             m = QLlamaDecoderLayer(
-#                 originalLayer=layers[i],
-#                 args=args,
-#             )
-#         elif isinstance(layers[i], QLlamaDecoderLayer):
-#             m = layers[i]
-# 
-#         if m is None:
-#             continue
-# 
-#         layer = m.to(device)
-# 
-#         block_layers = find_qlinear_layers(layer)
-# 
-#         sequential = [list(block_layers.keys())]
-#        
-#         for names in sequential:
-#             subset = {n: block_layers[n] for n in names}
-# 
-#             gptq = {}
-#             for name in subset:
-#                 gptq[name] = GPTQ(
-#                     subset[name], n_out=args.keeper, keeper_precision=args.keeper_precision
-#                 )
-#                 gptq[name].quantizer = Quantizer_GPTQ()
-#                 gptq[name].quantizer.configure(
-#                     args.wbits, perchannel=True, sym=args.w_sym, mse=False, 
-#                     channel_group=args.weight_channel_group,
-#                     clip_ratio=args.w_clip_ratio
-#                 )
-#                 
-#             def add_batch(name):
-#                 def tmp(_, inp, out):
-#                     gptq[name].add_batch(inp[0].data, out.data)
-#                 return tmp
-# 
-#             handles = []
-#             for name in subset:
-#                 handles.append(subset[name].register_forward_hook(add_batch(name)))
-#             for j in range(args.nsamples):
-#                 layer(inps[j].unsqueeze(0), attention_mask=attention_mask, position_ids=position_ids)[0]
-#             for h in handles:
-#                 h.remove()
-#             
-#             for name in subset:
-#                 gptq[name].fasterquant(
-#                     percdamp=args.percdamp, groupsize=args.weight_group_size
-#                 )
-#                 quantizers['model.layers.%d.%s' % (i, name)] = gptq[name].quantizer.cpu()
-#                 gptq[name].free()
-# 
-#             del gptq
-# 
-#         for j in range(args.nsamples):
-#             outs[j] = layer(inps[j].unsqueeze(0), attention_mask=attention_mask, position_ids=position_ids)[0]
-# 
-#         layers[i] = layer.cpu()
-#         del layer, m
-#         torch.cuda.empty_cache()
-#         gc.collect()
-# 
-#         inps, outs = outs, inps
-# 
-#     model.config.use_cache = use_cache
-#     return model

--- a/model/qLinearLayer.py
+++ b/model/qLinearLayer.py
@@ -4,7 +4,8 @@ from quant import fake_quantize_quarter_E5M2, fake_quantize_quarter_E4M3, quanti
 
 def find_qlinear_layers(module, name=''):
     if type(module) == QLinearLayer:
-        return {name: module}
+        if module.enable_quant:
+            return {name: module}
     res = {}
     for name1, child in module.named_children():
         res.update(find_qlinear_layers(
@@ -16,11 +17,13 @@ class QLinearLayer(nn.Module):
     def __init__(
         self,
         originalLayer: nn.Linear,
-        args
+        args,
+        enable_quant: bool = True
     ):
         super().__init__()
         self.args = args
         self.register_buffer('weight', originalLayer.weight)
+        self.enable_quant = enable_quant # whether to allow quant on weights, default True
         if originalLayer.bias is not None:
             self.register_buffer('bias', originalLayer.bias)
         else:

--- a/model/qLinearLayer.py
+++ b/model/qLinearLayer.py
@@ -72,6 +72,7 @@ class QLinearLayer(nn.Module):
         if self.args.keeper > 0:
             self.weight[:, -self.args.keeper:] = saved_w
             del saved_w
+        return
     
     def reorder(self, in_reorder_index, out_reorder_index=None):
         if self.args.reorder == True:
@@ -80,3 +81,4 @@ class QLinearLayer(nn.Module):
             if out_reorder_index is not None:
                 out_reorder_index = out_reorder_index.to(self.weight.device)
                 self.weight = torch.index_select(self.weight, 0, out_reorder_index)
+        return

--- a/model/qMixtralLayer.py
+++ b/model/qMixtralLayer.py
@@ -1,0 +1,435 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+from typing import List, Optional, Tuple
+import math
+import warnings
+# from transformers.models.llama.modeling_llama import LlamaDecoderLayer, LlamaRMSNorm, LlamaAttention, LlamaMLP
+from transformers.models.mixtral.modeling_mixtral import MixtralDecoderLayer, MixtralSparseMoeBlock, MixtralRMSNorm, MixtralAttention, MixtralBlockSparseTop2MLP
+from transformers.cache_utils import Cache
+from quant import Quantizer
+from qLinearLayer import QLinearLayer
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        position_ids (`torch.Tensor`):
+            The position indices of the tokens corresponding to the query and key tensors. For example, this can be
+            used to pass offsetted position ids when working with a KV-cache.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    cos = cos[position_ids].unsqueeze(unsqueeze_dim)
+    sin = sin[position_ids].unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+    num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+class QMixtralRMSNorm(nn.Module):
+    def __init__(
+        self,
+        originalRMSNorm: MixtralRMSNorm,
+        args
+    ):
+        super().__init__()
+        self.originalRMSNorm = originalRMSNorm
+        self.act_quant = lambda x: x
+        self.register_buffer("reorder_index", None)
+        self.args = args
+
+    @torch.no_grad()
+    def forward(self, hidden_states):
+        result = self.originalRMSNorm(hidden_states)
+        if self.reorder_index is not None:
+            assert result.shape[result.dim()-1] == self.reorder_index.shape[0]
+            result = torch.index_select(result, result.dim()-1, self.reorder_index)
+
+        if self.args.abits < 16:
+            result = self.act_quant(result)
+
+        return result
+    
+    def to(self, *args, **kwargs):
+        super(QMixtralRMSNorm, self).to(*args, **kwargs)
+        self.originalRMSNorm = self.originalRMSNorm.to(*args, **kwargs)
+        if self.reorder_index is not None:
+            self.reorder_index = self.reorder_index.to(*args, **kwargs)
+        return self
+
+
+class QMixtralAttention(nn.Module):
+    def __init__(
+            self, 
+            originalAttn: MixtralAttention,
+            args
+        ):
+        super().__init__()
+        self.config = originalAttn.config
+        self.layer_idx = originalAttn.layer_idx
+
+        self.hidden_size = originalAttn.hidden_size
+        self.num_heads = originalAttn.num_heads
+        self.head_dim = originalAttn.head_dim 
+        self.num_key_value_heads = originalAttn.num_key_value_heads
+        self.num_key_value_groups = originalAttn.num_key_value_groups
+        self.max_position_embeddings = originalAttn.max_position_embeddings
+        self.rope_theta = originalAttn.rope_theta
+        self.is_causal = True
+        self.attention_dropout = originalAttn.attention_dropout
+        self.register_buffer("reorder_index", None)
+
+        if (self.head_dim * self.num_heads) != self.hidden_size:
+            raise ValueError(
+                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
+                f" and `num_heads`: {self.num_heads})."
+            )
+
+        self.q_proj = QLinearLayer(originalAttn.q_proj, args)
+        self.k_proj = QLinearLayer(originalAttn.k_proj, args)
+        self.v_proj = QLinearLayer(originalAttn.v_proj, args)
+        self.o_proj = QLinearLayer(originalAttn.o_proj, args)
+
+        self.rotary_emb = originalAttn.rotary_emb
+
+        self.act_quant = lambda x: x
+        self.k_quant = lambda x: x
+        self.v_quant = lambda x: x
+
+        self.q_kv_cache = args.kv_cache
+
+    def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
+        return tensor.view(bsz, seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+
+    def to(self, *args, **kwargs):
+        super(QMixtralAttention, self).to(*args, **kwargs)
+        self.q_proj = self.q_proj.to(*args, **kwargs)
+        self.k_proj = self.k_proj.to(*args, **kwargs)
+        self.v_proj = self.v_proj.to(*args, **kwargs)
+        self.o_proj = self.o_proj.to(*args, **kwargs)
+        self.rotary_emb = self.rotary_emb.to(*args, **kwargs)
+
+        if self.reorder_index is not None:
+            self.reorder_index = self.reorder_index.to(*args, **kwargs)
+        return self
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Cache] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        if "padding_mask" in kwargs:
+            warnings.warn(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            )
+        bsz, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
+        kv_seq_len = key_states.shape[-2]
+        if past_key_value is not None:
+            if self.layer_idx is None:
+                raise ValueError(
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
+                    "with a layer index."
+                )
+            kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
+
+        # Fake quantize the key_states.
+        # Preserve the position embedding info by first quantize.
+        if self.q_kv_cache:
+            key_states = self.k_quant(key_states)
+
+        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+
+        if past_key_value is not None:
+            cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
+
+        # repeat k/v heads if n_kv_heads < n_heads
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+
+        # Fake quantize the value_states
+        if self.q_kv_cache:
+            value_states = self.v_quant(value_states)
+
+        if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
+            raise ValueError(
+                f"Attention weights should be of size {(bsz, self.num_heads, q_len, kv_seq_len)}, but is"
+                f" {attn_weights.size()}"
+            )
+
+        if attention_mask is not None:
+            if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+                raise ValueError(
+                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                )
+
+            attn_weights = attn_weights + attention_mask
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=self.training)
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
+
+        attn_output = self.act_quant(attn_output)
+        attn_output = self.o_proj(attn_output)
+
+        if not output_attentions:
+            attn_weights = None
+
+        return attn_output, attn_weights, past_key_value
+
+class QMixtralBlockSparseTop2MLP(nn.Module):
+    def __init__(
+        self, 
+        originalTop2MLP: MixtralBlockSparseTop2MLP,
+        args
+    ):
+        super().__init__()
+        self.ffm_dim = originalTop2MLP.ffn_dim
+        self.hidden_dim = originalTop2MLP.hidden_dim
+
+        self.w1 = QLinearLayer(originalTop2MLP.w1, args)
+        self.w2 = QLinearLayer(originalTop2MLP.w2, args)
+        self.w3 = QLinearLayer(originalTop2MLP.w3, args)
+
+        self.act_fn = originalTop2MLP.act_fn
+        self.act_quant = lambda x: x
+
+    def forward(self, hidden_states):
+        current_hidden_states = self.act_fn(self.w1(hidden_states)) * self.w3(hidden_states)
+        current_hidden_states = self.act_quant(current_hidden_states)
+        current_hidden_states = self.w2(current_hidden_states)
+        return current_hidden_states
+
+    def quant(self):
+        self.w1.quant()
+        self.w2.quant()
+        self.w3.quant()
+        return
+
+    def to(self, *args, **kwargs):
+        super(QMixtralBlockSparseTop2MLP, self).to(*args, **kwargs)
+        self.w1 = self.w1.to(*args, **kwargs)
+        self.w2 = self.w2.to(*args, **kwargs)
+        self.w3 = self.w3.to(*args, **kwargs)
+        return self
+
+
+class QMixtralSparseMoeBlock(nn.Module):
+    def __init__(
+        self,
+        originalMoeBlock: MixtralSparseMoeBlock,
+        args
+    ):
+        super().__init__()
+        self.hidden_dim = originalMoeBlock.hidden_dim
+        self.ffn_dim = originalMoeBlock.ffn_dim
+        self.num_experts = originalMoeBlock.num_experts
+        self.top_k = originalMoeBlock.top_k
+
+        # gating
+        self.gate = originalMoeBlock.gate
+
+        self.experts = nn.ModuleList(
+            [QMixtralBlockSparseTop2MLP(originalMoeBlock.experts[i], args) for i in range(self.num_experts)]
+        )
+
+    def to(self, *args, **kwargs):
+        super(QMixtralSparseMoeBlock, self).to(*args, **kwargs)
+        self.gate = self.gate.to(*args, **kwargs)
+        self.experts = self.experts.to(*args, **kwargs)
+        return self
+
+    @torch.no_grad()
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """ """
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        # router_logits: (batch * sequence_length, n_experts)
+        router_logits = self.gate(hidden_states)
+
+        routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+        # we cast back to the input dtype
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        final_hidden_states = torch.zeros(
+            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+        )
+
+        # One hot encode the selected experts to create an expert mask
+        # this will be used to easily index which expert is going to be sollicitated
+        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+
+        # Loop over all available experts in the model and perform the computation on each expert
+        for expert_idx in range(self.num_experts):
+            expert_layer = self.experts[expert_idx]
+            idx, top_x = torch.where(expert_mask[expert_idx])
+
+            if top_x.shape[0] == 0:
+                continue
+
+            # in torch it is faster to index using lists than torch tensors
+            top_x_list = top_x.tolist()
+            idx_list = idx.tolist()
+
+            # Index the correct hidden states and compute the expert hidden state for
+            # the current expert. We need to make sure to multiply the output hidden
+            # states by `routing_weights` on the corresponding tokens (top-1 and top-2)
+            current_state = hidden_states[None, top_x_list].reshape(-1, hidden_dim)
+            current_hidden_states = expert_layer(current_state) * routing_weights[top_x_list, idx_list, None]
+
+            # However `index_add_` only support torch tensors for indexing so we'll use
+            # the `top_x` tensor here.
+            final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
+        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+        return final_hidden_states, router_logits
+
+
+class QMixtralDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        originalLayer: MixtralDecoderLayer,
+        args
+    ):
+        super().__init__()
+        self.args = args
+        self.hidden_size = originalLayer.hidden_size
+
+        self.self_attn = QMixtralAttention(originalLayer.self_attn, args)
+
+        self.block_sparse_moe = QMixtralSparseMoeBlock(originalLayer.block_sparse_moe, args)
+        self.input_layernorm = QMixtralRMSNorm(originalLayer.input_layernorm, args)
+        self.post_attention_layernorm = QMixtralRMSNorm(originalLayer.post_attention_layernorm, args)
+
+    def to(self, *args, **kwargs):
+        super(QMixtralDecoderLayer, self).to(*args, **kwargs)
+        self.self_attn = self.self_attn.to(*args, **kwargs)
+        self.block_sparse_moe = self.block_sparse_moe.to(*args, **kwargs)
+        self.input_layernorm = self.input_layernorm.to(*args, **kwargs)
+        self.post_attention_layernorm = self.post_attention_layernorm.to(*args, **kwargs)
+        return self
+    
+    @torch.no_grad()
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        output_attentions: Optional[bool] = False,
+        output_router_logits: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+        **kwargs,
+    ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+        if "padding_mask" in kwargs:
+            warnings.warn(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            )
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`, *optional*): attention mask of size
+                `(batch, sequence_length)` where padding elements are indicated by 0.
+            past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+            output_router_logits (`bool`, *optional*):
+                Whether or not to return the logits of all the routers. They are useful for computing the router loss, and
+                should not be returned during inference.
+            use_cache (`bool`, *optional*):
+                If set to `True`, `past_key_values` key value states are returned and can be used to speed up decoding
+                (see `past_key_values`).
+        """
+
+        residual = hidden_states
+
+        hidden_states = self.input_layernorm(hidden_states)
+
+        # Self Attention
+        hidden_states, self_attn_weights, present_key_value = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+        )
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states, router_logits = self.block_sparse_moe(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (self_attn_weights,)
+
+        if use_cache:
+            outputs += (present_key_value,)
+
+        if output_router_logits:
+            outputs += (router_logits,)
+
+        return outputs

--- a/model/requirements.txt
+++ b/model/requirements.txt
@@ -1,5 +1,5 @@
 torch==2.1.0
-transformers==4.36.2
+transformers==4.39.0
 accelerate==0.24.1
 datasets==2.14.6
 zstandard==0.22.0
@@ -12,4 +12,4 @@ omegaconf==2.3.0
 pycountry==22.3.5
 rouge-score==0.1.2
 lm-eval==0.3.0
-bitsandbytes=0.43.0
+bitsandbytes==0.43.0


### PR DESCRIPTION
Add simulated quantization for Mixtral8x7b. 
One major difference to Llama is that we move the activation quantization to after the gate operation of the SpareMoeBlock.
I also update the transformers library version to 3.39.0 for better support on the Mixtral model.
Currently, we have 4.41 perplexity on wikitext2 for W4A4 quantization.